### PR TITLE
Update Email CRD to latest API version to support direct emailAddress recipients

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.6.1
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.7.1
     with:
       image-name: email-provider-resend
     secrets: inherit
@@ -20,7 +20,7 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.5.1
+    uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.7.1
     with:
       bundle-name: ghcr.io/datum-cloud/email-provider-resend-kustomize
       bundle-path: config

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Complete Kubernetes operator implementation that integrates Resend email servic
 *   Leader election for HA deployments
     
 
-Provides reliable, observable email delivery for the Milo notification system.
+Provides reliable, observable email delivery for the Milo notification system. 

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Complete Kubernetes operator implementation that integrates Resend email servic
 *   Leader election for HA deployments
     
 
-Provides reliable, observable email delivery for the Milo notification system. 
+Provides reliable, observable email delivery for the Milo notification system.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
-require go.miloapis.com/milo v0.2.1-0.20250828133344-527517c40e60
+require go.miloapis.com/milo v0.4.2-0.20250917205403-84d9e2aca04d
 
 require github.com/resend/resend-go/v2 v2.23.0
 

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.miloapis.com/milo v0.2.1-0.20250828133344-527517c40e60 h1:9Tiw0j80TVf7gDdZGJ0PquaSIRwIttQ/qs1sTCLCJzI=
 go.miloapis.com/milo v0.2.1-0.20250828133344-527517c40e60/go.mod h1:EmePGXYUFOx5nr9fo7OT8HN1K7m7+6rs2/swWo+9AiQ=
+go.miloapis.com/milo v0.4.2-0.20250917205403-84d9e2aca04d h1:Zr0/wo7Nrx38EMn/zz++eb6AZcml78LNbH/hbMqa4+A=
+go.miloapis.com/milo v0.4.2-0.20250917205403-84d9e2aca04d/go.mod h1:bbt+tA+BBvQS6s628ar9fbsB3V/2GSQk1c6bp16e1ks=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 h1:Hf9xI/XLML9ElpiHVDNwvqI0hIFlzV8dgIr35kV1kRU=

--- a/internal/emailprovider/service.go
+++ b/internal/emailprovider/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	iammiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/iam/v1alpha1"
 	notificationmiloapiscomv1alpha1 "go.miloapis.com/milo/pkg/apis/notification/v1alpha1"
 
 	emailtemplating "go.miloapis.com/email-provider-resend/internal/emailtemplanting"
@@ -31,7 +30,7 @@ func NewService(provider EmailProvider, from, replyTo string) *Service {
 func (s *Service) Send(ctx context.Context,
 	email *notificationmiloapiscomv1alpha1.Email,
 	template *notificationmiloapiscomv1alpha1.EmailTemplate,
-	userRecipient *iammiloapiscomv1alpha1.User,
+	recipientEmailAddress string,
 ) (SendEmailOutput, error) {
 	// variables are already validated by Milo webhooks
 	// to match the referenced template
@@ -59,7 +58,7 @@ func (s *Service) Send(ctx context.Context,
 	return s.provider.SendEmail(ctx, SendEmailInput{
 		From:           s.from,
 		ReplyTo:        s.replyTo,
-		To:             []string{userRecipient.Spec.Email},
+		To:             []string{recipientEmailAddress},
 		Cc:             email.Spec.CC,
 		Bcc:            email.Spec.BCC,
 		Subject:        subject,


### PR DESCRIPTION
This pull request upgrades our integration to the newest version of the Milo notification.miloapis.com/v1alpha1 Email API, unlocking flexible recipient targeting and updating controller logic accordingly.

**Key points**
Emails can now be targeted directly via `emailAddress`, in addition to the existing `userRef`.