### PR TITLE
Add production hostname for email provider resend configuration

### DIFF
--- a/config/base/services/ingress/email-provider-resend.yaml
+++ b/config/base/services/ingress/email-provider-resend.yaml
@@ -9,6 +9,7 @@ spec:
       sectionName: resend
   hostnames:
     - resend.staging.env.datum.net
+    - resend.prod.env.datum.net
   rules:
     - matches:
         - path:


### PR DESCRIPTION
This PR adds the necessary host name for receiving the resend webhooks 