### PR TITLE
Publish multi-arch (amd64 + arm64) container images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,10 @@ jobs:
       id-token: write
       contents: read
       packages: write
-    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
       image-name: email-provider-resend
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   publish-kustomize-bundles:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -20,7 +24,13 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o email-provider-resend ./cmd
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+  -ldflags "-s -w \
+    -X main.version=${VERSION} \
+    -X main.gitCommit=${GIT_COMMIT} \
+    -X main.gitTreeState=${GIT_TREE_STATE} \
+    -X main.buildDate=${BUILD_DATE}" \
+  -a -o email-provider-resend ./cmd
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,11 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	version      = "dev"
+	gitCommit    = "unknown"
+	gitTreeState = "unknown"
+	buildDate    = "unknown"
 )
 
 func init() {

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -137,7 +137,12 @@ func createManagerCommand() *cobra.Command {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	setupLog.Info("starting email-provider-resend", "version", version, "gitCommit", gitCommit, "gitTreeState", gitTreeState, "buildDate", buildDate)
+	setupLog.Info("starting email-provider-resend",
+		"version", version,
+		"gitCommit", gitCommit,
+		"gitTreeState", gitTreeState,
+		"buildDate", buildDate,
+	)
 
 	return cmd
 }

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -137,6 +137,8 @@ func createManagerCommand() *cobra.Command {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	setupLog.Info("starting email-provider-resend", "version", version, "gitCommit", gitCommit, "gitTreeState", gitTreeState, "buildDate", buildDate)
+
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Our published container images are currently amd64-only, which means anyone running on Apple Silicon (or other arm64 hardware) can't pull and run them natively. This PR unblocks arm64 users by publishing both amd64 and arm64 images from CI.

Under the hood the build now cross-compiles natively for each target architecture instead of falling back to QEMU emulation, so building arm64 is no longer painfully slow. A local multi-arch build on my machine finishes in about 1m06s. For reference, the equivalent change on workload-operator (#82) brought a cold GHA run from 15+ minutes down to 4m31s.

Also wires VERSION / GIT_COMMIT / GIT_TREE_STATE / BUILD_DATE through as Docker build args and ldflags, and logs them at manager startup so we can tell what's actually running.

## Test plan

- [ ] CI green on this PR
- [ ] Published image manifest lists both linux/amd64 and linux/arm64
- [ ] Pull and run the arm64 image on Apple Silicon without emulation
- [ ] Manager startup log shows version / gitCommit / buildDate

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>