### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.9.0
     with:
-      bundle-name: ghcr.io/datum-cloud/email-provider-resend-kustomize
+      bundle-name: ghcr.io/milo-os/resend-provider-kustomize
       bundle-path: config
       image-overlays: config/base
-      image-name: ghcr.io/datum-cloud/email-provider-resend
+      image-name: ghcr.io/milo-os/resend-provider
       debug: true
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.13.1
     with:
+      registry-organization: milo-os
       image-name: email-provider-resend
       platforms: linux/amd64,linux/arm64
     secrets: inherit

--- a/config/base/services/manager/kustomization.yaml
+++ b/config/base/services/manager/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - manager.yaml
 - metrics-service.yaml
 images:
-- name: ghcr.io/datum-cloud/email-provider-resend
+- name: ghcr.io/milo-os/resend-provider
   newTag: latest

--- a/config/base/services/manager/manager.yaml
+++ b/config/base/services/manager/manager.yaml
@@ -110,7 +110,7 @@ spec:
           - secretRef:
               name: resend-keys # MUST contain the key RESEND_API_KEY
 
-        image: ghcr.io/datum-cloud/email-provider-resend:latest
+        image: ghcr.io/milo-os/resend-provider:latest
         name: controller-manager
         
         ports:

--- a/config/base/services/webhook/kustomization.yaml
+++ b/config/base/services/webhook/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - resend-webhook.yaml
 - resend-webhook-service.yaml
 images:
-- name: ghcr.io/datum-cloud/email-provider-resend
+- name: ghcr.io/milo-os/resend-provider
   newTag: latest

--- a/config/base/services/webhook/resend-webhook.yaml
+++ b/config/base/services/webhook/resend-webhook.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: resend-webhook
-          image: ghcr.io/datum-cloud/email-provider-resend:latest
+          image: ghcr.io/milo-os/resend-provider:latest
           imagePullPolicy: IfNotPresent
           args:
             - resend-webhook


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.